### PR TITLE
Pyproject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Fixed `compas_libigl` plugins are not detected.
+* Add project dependency groups in pyproject.toml.
 
 ### Removed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,18 +12,36 @@ authors = [
     { name = "Petras Vestartas", email = "petrasvestartas@gmail.com" },
 ]
 classifiers = ["License :: OSI Approved :: BSD License"]
-dynamic = ['dependencies', 'optional-dependencies', 'version']
+
+dynamic = ['version']
+dependencies = [
+    "compas >=2.0.0",
+    "tessagon",
+]
 
 [project.urls]
 Homepage = "https://compas.dev/compas_libigl/latest/"
 
 # ============================================================================
-# setuptools config
+# pyproject dependecy groups
 # ============================================================================
 
-[tool.setuptools.dynamic]
-dependencies = { file = "requirements.txt" }
-optional-dependencies = { dev = { file = "requirements-dev.txt" } }
+[dependency-groups]
+dev = [
+    "ruff",
+    "pre-commit",
+    "build",
+    { include-group = "tests" },
+    { include-group = "docs" },
+]
+tests = [
+    "pytest",
+    "numpy",
+]
+docs = [
+    "sphinx",
+    "sphinx-compas-theme",
+]
 
 # ============================================================================
 # pytest configuration


### PR DESCRIPTION
@tomvanmele could you please make another release after the merge of this pull-request?

Project dependency groups were missing from the last commit.
Locally, compas and tessagon are installed.

